### PR TITLE
Add support for +w wasm integration

### DIFF
--- a/syntaxes/djinni.tmLanguage.json
+++ b/syntaxes/djinni.tmLanguage.json
@@ -136,7 +136,7 @@
 		"record": {
 			"patterns": [
 				{
-					"begin": "(\\w+)\\s*(=)\\s*(record)\\s+((\\+[cjops]\\s+)*)({)",
+					"begin": "(\\w+)\\s*(=)\\s*(record)\\s+((\\+[cjopsw]\\s+)*)({)",
 					"beginCaptures": {
 						"1": { "name": "variable.name" },
 						"2": { "name": "keyword.operator.djinni" },
@@ -179,7 +179,7 @@
 		"interface": {
 			"patterns": [
 				{
-					"begin": "(\\w+)\\s*(=)\\s*(interface)\\s+((\\+[cjops]\\s+)*)({)",
+					"begin": "(\\w+)\\s*(=)\\s*(interface)\\s+((\\+[cjopsw]\\s+)*)({)",
 					"beginCaptures": {
 						"1": { "name": "variable.name" },
 						"2": { "name": "keyword.operator.djinni" },


### PR DESCRIPTION
fixes #14 

@paulo-coutinho requested to just support any letter after the `+`. For this PR I've instead decided to just add wasm support like we've added [python (`+p`)](https://github.com/cross-language-cpp/vscode-djinni/commit/4e9704d4ef8737d7282961d67543ce69b8a35ae1) and [csharp (`+s`)](https://github.com/cross-language-cpp/vscode-djinni/commit/54f0042a9e3511a23dc4cd0f3bbe19d1f1608450) before. I'm not sure which is the way to go tbh, looking forward to your opinion on that! 